### PR TITLE
Fix typo in analyzer prompt

### DIFF
--- a/intabular/core/analyzer.py
+++ b/intabular/core/analyzer.py
@@ -164,7 +164,7 @@ class DataframeAnalyzer:
                 
                 Please determine:
                 
-                1. HEADER DETECTION: Does the first row contain column headers or actual data/palceholder values?
+                1. HEADER DETECTION: Does the first row contain column headers or actual data/placeholder values?
                    - Headers: descriptive names like ["name", "email", "company", "first_name"]  
                    - Data: actual values like ["John Smith", "john@example.com", "Acme Corp"] or placeholder values like ["1", "2", "3"]
                 


### PR DESCRIPTION
## Summary
- fix a typo in the dataframe analyzer prompt

## Testing
- `python test/run_essential_tests.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad2dd1f0832580fec14951ecf488